### PR TITLE
Migrate postcss config to .postcssrc

### DIFF
--- a/.postcssrc
+++ b/.postcssrc
@@ -1,5 +1,5 @@
-export default {
+{
   plugins: {
     "@tailwindcss/postcss": {},
   },
-};
+}


### PR DESCRIPTION
When starting Parcel using Yarn, a warning was shown saying:

```
❯ yarn start
yarn run v1.22.22
$ parcel 'src/**/*'
Server running at http://localhost:1234

@parcel/transformer-postcss: WARNING: Using a JavaScript PostCSS config file means losing out on caching features of Parcel. Use a .postcssrc(.json)
file whenever possible.
✨ Built in 21ms
```

Now, with the config in .postcssrc, no warning is shown.

Granted it's only a small sample size, the build times do actually seem to be faster so the warning was justified.

```
❯ yarn start
yarn run v1.22.22
$ parcel 'src/**/*'
Server running at http://localhost:1234
✨ Built in 3ms
```