### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        labels:
+          - "dependencies"
+          - "dependabot"
+          - "npm"
+          - "deps:minor-patch"
+      major:
+        update-types:
+          - "major"
+        labels:
+          - "dependencies"
+          - "dependabot"
+          - "npm"
+          - "deps:major"


### PR DESCRIPTION
Group Dependabot updates into (major) and (minor & patch) groups. This should reduce the number of PRs that are opened to a max of 2 per week.